### PR TITLE
Revert "Bump word-wrap from 1.2.3 to 1.2.5 in /application/server"

### DIFF
--- a/application/server/package-lock.json
+++ b/application/server/package-lock.json
@@ -7634,9 +7634,9 @@
       }
     },
     "word-wrap": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
-      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
     },
     "wrap-ansi": {
       "version": "2.1.0",


### PR DESCRIPTION
Reverts IBM/fabric-contract-attribute-based-access-control#77