### PR TITLE
Revert "Bump follow-redirects from 1.9.0 to 1.15.5 in /application/client"

### DIFF
--- a/application/client/package-lock.json
+++ b/application/client/package-lock.json
@@ -3722,10 +3722,13 @@
       }
     },
     "follow-redirects": {
-      "version": "1.15.5",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
-      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
-      "dev": true
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.9.0.tgz",
+      "integrity": "sha512-CRcPzsSIbXyVDl0QI01muNDu69S8trU4jArW9LpOt2WtC6LyUJetcIrmfHsRBx7/Jb6GHJUiuqyYxPooFfNt6A==",
+      "dev": true,
+      "requires": {
+        "debug": "^3.0.0"
+      }
     },
     "for-in": {
       "version": "1.0.2",


### PR DESCRIPTION
Reverts IBM/fabric-contract-attribute-based-access-control#73